### PR TITLE
Update eigenMT.py

### DIFF
--- a/eigenMT.py
+++ b/eigenMT.py
@@ -217,7 +217,7 @@ def bf_eigen_windows(test_dict, gen_dict, phepos_dict, OUT_fh, input_header, var
 			if stop - start == 1:
 				m_eff += 1
 				break ##can't compute eigenvalues for a scalar, so add 1 to m_eff and break from the while loop
-			snps_window = snps[start:stop]
+			snps_window = snps[int(start):int(stop)]
 			genotypes = []
 			for snp in snps_window:
 				if snp in gen_dict:

--- a/eigenMT.py
+++ b/eigenMT.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2.7
 import os
 import sys
 import fileinput


### PR DESCRIPTION
problem:
In my environment (python=2.7.16=h8b3fad2_5, numpy=1.16.4=py27h95a1406_0, scipy=1.2.1=py27h921218d_2, scikit-learn=0.20.3=py27ha8026db_1) running the eigenMT with the provided test data ran into errors related to slicing with numpy floats.

solution:
explicitly cast start and stop into integer to prevent slicing errors.